### PR TITLE
Add the fp8 version of fused-moe

### DIFF
--- a/vllm/model_executor/layers/fused_moe/fused_moe.py
+++ b/vllm/model_executor/layers/fused_moe/fused_moe.py
@@ -150,6 +150,144 @@ def fused_moe_kernel(
     tl.store(c_ptrs, accumulator, mask=c_mask)
 
 
+@triton.jit
+def fused_moe_kernel_fp8(
+    a_ptr,
+    b_ptr,
+    c_ptr,
+    scale_ptr,
+    topk_weights_ptr,
+    sorted_token_ids_ptr,
+    expert_ids_ptr,
+    num_tokens_post_padded_ptr,
+    N,
+    K,
+    EM,
+    num_valid_tokens,
+    stride_am,
+    stride_ak,
+    stride_be,
+    stride_bk,
+    stride_bn,
+    stride_cm,
+    stride_cn,
+    quantization_group_size,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    MUL_ROUTED_WEIGHT: tl.constexpr,
+    top_k: tl.constexpr,
+    compute_type: tl.constexpr,
+):
+    """
+    Implements the fused computation for a Mixture of Experts (MOE) using
+    token and expert matrices.
+
+    Key Parameters:
+    - A: The input tensor representing tokens with shape (*, K), where '*' can
+        be any shape representing batches and K is the feature dimension of
+        each token.
+    - B: The stacked MOE weight tensor with shape (E, N, K), where E is
+        the number of experts, K is the input feature dimension, and N is
+        the output feature dimension.
+    - C: The output cache tensor with shape (M, topk, N), where M is the
+        total number of tokens post padding, topk is the number of times
+        each token is repeated, and N is the output feature dimension.
+    - sorted_token_ids: A tensor containing the sorted indices of tokens,
+        repeated topk times and arranged by the expert index they are
+        assigned to.
+    - expert_ids: A tensor containing the indices of the expert for each
+        block. It determines which expert matrix from B should be used for
+        each block in A.
+    This kernel performs the multiplication of a token by its corresponding
+    expert matrix as determined by `expert_ids`. The sorting of
+    `sorted_token_ids` by expert index and padding ensures divisibility by
+    BLOCK_SIZE_M, which is necessary to maintain consistency in block matrix
+    multiplication across different blocks processed by the same expert.
+    """
+    # -----------------------------------------------------------
+    # Map program ids `pid` to the block of C it should compute.
+    # This is done in a grouped ordering to promote L2 data reuse.
+    pid = tl.program_id(axis=0)
+    num_pid_m = tl.cdiv(EM, BLOCK_SIZE_M)
+    num_pid_n = tl.cdiv(N, BLOCK_SIZE_N)
+    num_pid_in_group = GROUP_SIZE_M * num_pid_n
+    group_id = pid // num_pid_in_group
+    first_pid_m = group_id * GROUP_SIZE_M
+    group_size_m = min(num_pid_m - first_pid_m, GROUP_SIZE_M)
+    pid_m = first_pid_m + ((pid % num_pid_in_group) % group_size_m)
+    pid_n = (pid % num_pid_in_group) // group_size_m
+
+    # ----------------------------------------------------------
+    # Create pointers for the first blocks of A and B.
+    # We will advance this pointer as we move in the K direction
+    # and accumulate
+    # `a_ptrs` is a block of [BLOCK_SIZE_M, BLOCK_SIZE_K] pointers
+    # `b_ptrs` is a block of [BLOCK_SIZE_K, BLOCK_SIZE_N] pointers
+    num_tokens_post_padded = tl.load(num_tokens_post_padded_ptr)
+    if pid_m * BLOCK_SIZE_M >= num_tokens_post_padded:
+        return
+    offs_token_id = pid_m * BLOCK_SIZE_M + tl.arange(0, BLOCK_SIZE_M)
+    offs_token = tl.load(sorted_token_ids_ptr + offs_token_id)
+    token_mask = offs_token < num_valid_tokens
+
+    offs_bn_base = ((pid_n * BLOCK_SIZE_N + tl.arange(0, BLOCK_SIZE_N)) % N) * stride_bn
+    offs_bn = offs_bn_base % quantization_group_size
+    offs_k = tl.arange(0, BLOCK_SIZE_K)
+    a_ptrs = a_ptr + (offs_token[:, None] // top_k * stride_am +
+                      offs_k[None, :] * stride_ak)
+
+    off_experts = tl.load(expert_ids_ptr + pid_m) * stride_be
+    b_ptrs = b_ptr + off_experts + (offs_k[:, None] * stride_bk + offs_bn[None, :])
+    b_scale_offset = off_experts + offs_bn_base
+    # -----------------------------------------------------------
+    # Iterate to compute a block of the C matrix.
+    # We accumulate into a `[BLOCK_SIZE_M, BLOCK_SIZE_N]` block
+    # of fp32 values for higher accuracy.
+    # `accumulator` will be converted back to fp16 after the loop.
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    for k in range(0, tl.cdiv(K, BLOCK_SIZE_K)):
+        # Load the next block of A and B, generate a mask by checking the
+        # K dimension.
+        b_group_id = (b_scale_offset + k * BLOCK_SIZE_K) // quantization_group_size
+        # reading the scales in FP32-format from the shard fp8-tensor pointer, 
+        # so we divide the group-size by 4 to acount for that
+        scale = tl.load(scale_ptr + (b_group_id + 1) * (quantization_group_size // 4))
+        a = tl.load(a_ptrs,
+                    mask=token_mask[:, None] &
+                    (offs_k[None, :] < K - k * BLOCK_SIZE_K),
+                    other=0.0)
+        b = tl.load(b_ptrs + b_group_id * (quantization_group_size + 4),
+                    mask=offs_k[:, None] < K - k * BLOCK_SIZE_K,
+                    other=0.0).to(compute_type)
+
+        # (TODO: Reza) check if using bf16 scales is possible. 
+        # Or, we could even move the scale after MMA!
+        b = b * scale[None, :].to(compute_type)
+        accumulator += tl.dot(a, b)
+
+        # Advance the ptrs to the next K block.
+        a_ptrs += BLOCK_SIZE_K * stride_ak
+        b_ptrs += BLOCK_SIZE_K * stride_bk
+
+    if MUL_ROUTED_WEIGHT:
+        moe_weight = tl.load(topk_weights_ptr + offs_token,
+                             mask=token_mask,
+                             other=0)
+        accumulator = accumulator * moe_weight[:, None]
+
+    accumulator = accumulator.to(compute_type)
+    # -----------------------------------------------------------
+    # Write back the block of the output
+    offs_cn = pid_n * BLOCK_SIZE_N + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = c_ptr + stride_cm * offs_token[:, None] + stride_cn * offs_cn[
+        None, :]
+    c_mask = token_mask[:, None] & (offs_cn[None, :] < N)
+    tl.store(c_ptrs, accumulator, mask=c_mask)
+
+
 def moe_align_block_size(
         topk_ids: torch.Tensor, block_size: int,
         num_experts: int) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
@@ -245,6 +383,47 @@ def invoke_fused_moe_kernel(A: torch.Tensor, B: torch.Tensor, C: torch.Tensor,
     )
 
 
+def invoke_fused_moe_kernel_fp8(A: torch.Tensor, B: torch.Tensor, C: torch.Tensor, q_scales: torch.Tensor,
+                            topk_weights: torch.Tensor, topk_ids: torch.Tensor,
+                            sorted_token_ids: torch.Tensor,
+                            expert_ids: torch.Tensor,
+                            num_tokens_post_padded: torch.Tensor,
+                            mul_routed_weight: bool, top_k: int,
+                            quantization_group_size: int,
+                            config: Dict[str, Any]) -> None:
+    assert topk_weights.stride(1) == 1
+    assert sorted_token_ids.stride(0) == 1
+
+    grid = lambda META: (triton.cdiv(sorted_token_ids.shape[0], META[
+        'BLOCK_SIZE_M']) * triton.cdiv(B.shape[1], META['BLOCK_SIZE_N']), )
+        
+    fused_moe_kernel_fp8[grid](
+        A,
+        B,
+        C,
+        q_scales,
+        topk_weights,
+        sorted_token_ids,
+        expert_ids,
+        num_tokens_post_padded,
+        B.shape[1],
+        B.shape[2],
+        sorted_token_ids.shape[0],
+        topk_ids.numel(),
+        A.stride(0),
+        A.stride(1),
+        B.stride(0),
+        B.stride(2),
+        B.stride(1),
+        C.stride(1),
+        C.stride(2),
+        quantization_group_size,
+        MUL_ROUTED_WEIGHT=mul_routed_weight,
+        top_k=top_k,
+        compute_type=tl.bfloat16 if A.dtype == torch.bfloat16 else tl.float16,
+        **config,
+    )
+
 def get_config_file_name(E: int, N: int) -> str:
     device_name = torch.cuda.get_device_name().replace(" ", "_")
     return f"E={E},N={N},device_name={device_name}.json"
@@ -331,6 +510,9 @@ def fused_experts(
     topk_ids: torch.Tensor,
     inplace: bool = False,
     override_config: Optional[Dict[str, Any]] = None,
+    w1_q_scales: Optional[Dict[torch.Tensor, Any]] = None,
+    w2_q_scales: Optional[Dict[torch.Tensor, Any]] = None,
+    quantization_group_size: Optional[int] = 256
 ):
     # Check constraints.
     assert hidden_states.shape[1] == w1.shape[2], "Hidden size mismatch"
@@ -383,12 +565,24 @@ def fused_experts(
                                       dtype=hidden_states.dtype)
     sorted_token_ids, expert_ids, num_tokens_post_padded = moe_align_block_size(
         topk_ids, config['BLOCK_SIZE_M'], E)
-    invoke_fused_moe_kernel(hidden_states, w1, intermediate_cache1,
+    if w1.dtype == torch.float8_e4m3fn:
+        invoke_fused_moe_kernel_fp8(hidden_states, w1, intermediate_cache1, w1_q_scales,
+                            topk_weights, topk_ids, sorted_token_ids,
+                            expert_ids, num_tokens_post_padded, False,
+                            topk_ids.shape[1], quantization_group_size, config)
+    else:
+        invoke_fused_moe_kernel(hidden_states, w1, intermediate_cache1,
                             topk_weights, topk_ids, sorted_token_ids,
                             expert_ids, num_tokens_post_padded, False,
                             topk_ids.shape[1], config)
     ops.silu_and_mul(intermediate_cache2, intermediate_cache1.view(-1, N))
-    invoke_fused_moe_kernel(intermediate_cache2, w2, intermediate_cache3,
+    if w2.dtype == torch.float8_e4m3fn:
+        invoke_fused_moe_kernel_fp8(intermediate_cache2, w2, intermediate_cache3, w2_q_scales,
+                            topk_weights, topk_ids, sorted_token_ids,
+                            expert_ids, num_tokens_post_padded, False,
+                            topk_ids.shape[1], quantization_group_size, config)
+    else:
+        invoke_fused_moe_kernel(intermediate_cache2, w2, intermediate_cache3,
                             topk_weights, topk_ids, sorted_token_ids,
                             expert_ids, num_tokens_post_padded, True, 1,
                             config)
@@ -409,6 +603,9 @@ def fused_moe(
     renormalize: bool,
     inplace: bool = False,
     override_config: Optional[Dict[str, Any]] = None,
+    w1_q_scales: Optional[Dict[torch.Tensor, Any]] = None,
+    w2_q_scales: Optional[Dict[torch.Tensor, Any]] = None,
+    quantization_group_size: Optional[int] = 256
 ) -> torch.Tensor:
     """
     This function computes a Mixture of Experts (MoE) layer using two sets of
@@ -433,12 +630,7 @@ def fused_moe(
     # Check constraints.
     assert gating_output.shape[1] == w1.shape[0], "Number of experts mismatch"
 
-    topk_weights, topk_ids = fused_topk(hidden_states, gating_output, topk,
-                                        renormalize)
-    return fused_experts(hidden_states,
-                         w1,
-                         w2,
-                         topk_weights,
-                         topk_ids,
-                         inplace=inplace,
-                         override_config=override_config)
+    topk_weights, topk_ids = fused_topk(hidden_states, gating_output,
+                                        topk, renormalize)
+    return fused_experts(hidden_states, w1, w2, topk_weights, topk_ids,
+                         inplace=inplace, override_config=override_config, w1_q_scales=w1_q_scales, w2_q_scales=w2_q_scales, quantization_group_size=quantization_group_size)

--- a/vllm/model_executor/layers/quantization/deepspeedfp.py
+++ b/vllm/model_executor/layers/quantization/deepspeedfp.py
@@ -1,9 +1,8 @@
-import copy
 from typing import Any, Dict, List, Optional
 
 import torch
-import torch.nn as nn
 import torch.nn.functional as F
+import torch.nn as nn 
 
 from vllm.model_executor.layers.linear import (LinearMethodBase,
                                                set_weight_attrs)
@@ -19,7 +18,7 @@ class DeepSpeedFPConfig(QuantizationConfig):
         weight_bits: int = 8,
         rounding: str = "nearest",
         mantissa_bits: int = 3,
-        q_range=480.0,
+        q_range = 480.0,
         group_size: int = 512,
     ) -> None:
         self.weight_bits = weight_bits
@@ -32,8 +31,8 @@ class DeepSpeedFPConfig(QuantizationConfig):
         if self.weight_bits not in [6, 8]:
             raise ValueError(
                 "Currently, only 6-bit or 8-bit weight quantization are "
-                f"supported for DeepSpeed FP quantizaiton, but got "
-                f"{self.weight_bits} bits.")
+                f"supported for DeepSpeed FP quantizaiton, but got {self.weight_bits} bits."
+            )
 
     def __repr__(self) -> str:
         return (f"DeepSpeedFPConfig(weight_bits={self.weight_bits}), "
@@ -70,7 +69,7 @@ class DeepSpeedFPConfig(QuantizationConfig):
     @staticmethod
     def get_config_filenames() -> List[str]:
         return [
-            "quant_config.json",
+            "quant_config.json", 
             "quantize_config.json",
         ]
 
@@ -85,36 +84,39 @@ class DeepSpeedFPLinearMethod(LinearMethodBase):
     def __init__(self, quant_config: DeepSpeedFPConfig):
         self.quant_config = quant_config
         self.weight = None
-
-    def create_weights(self, layer: torch.nn.Module,
-                       input_size_per_partition: int,
-                       output_size_per_partition: int, input_size: int,
-                       output_size: int, params_dtype: torch.dtype,
-                       weight_loader=None, **extra_weight_attrs):
-        del output_size
-        weight = DeepSpeedFPParameter(
-            torch.Size((output_size_per_partition,
-                        input_size_per_partition)),
-            params_dtype=params_dtype,
-            quant_config=self.quant_config,
+        self.q_weight = None
+        # create the quantizer
+        from deepspeed.ops.fp_quantizer import FP_Quantize
+        self.quantizer = FP_Quantize(
+            group_size=self.quant_config.group_size,
         )
-        set_weight_attrs(weight, {
-            "input_dim": 1,
-            "output_dim": 0,
+
+    def create_weights(self,
+                       layer: torch.nn.Module,
+                       input_size_per_partition: int,
+                       output_size_per_partition: int,
+                       input_size: int,
+                       output_size: int,
+                       params_dtype: torch.dtype,
+                       **extra_weight_attrs):
+        del output_size
+        group_size = self.quant_config.group_size
+        orig_numel = input_size_per_partition * output_size_per_partition
+        weight = DeepSpeedFPQuantizedParameter(
+            torch.empty(
+                output_size_per_partition,
+                input_size_per_partition,
+                dtype=params_dtype
+            ).cpu(),
+            requires_grad=False,
+            quantization=self.quant_config,
+        )
+        set_weight_attrs(
+            weight, {
+                "input_dim": 1,
+                "output_dim": 0,
         })
         layer.register_parameter("weight", weight)
-
-        def quant_weight_loader(param, loaded_weight, *args, **kwargs):
-            # Calls the original weight loader (if any), quantizes the result,
-            # and then loads the quantized parameter.
-            if weight_loader is not None:
-                orig_param_data = param.data
-                param.data = param.ds_dequantize()
-                weight_loader(param, loaded_weight, *args, **kwargs)
-                param.data, loaded_weight = orig_param_data, param.data
-            param.ds_quantize_(loaded_weight.cuda())
-
-        extra_weight_attrs["weight_loader"] = quant_weight_loader
         set_weight_attrs(weight, extra_weight_attrs)
 
     def apply_weights(self,
@@ -122,56 +124,121 @@ class DeepSpeedFPLinearMethod(LinearMethodBase):
                       x: torch.Tensor,
                       bias: Optional[torch.Tensor] = None) -> torch.Tensor:
         weight = layer.weight
-        y = weight.ds_dequantize()
+        y = weight.dequantized()
         return F.linear(x, y, bias)
 
+    def dequantize(self, weight):
+        assert (weight.data.dtype == torch.int8 or weight.data.dtype == torch.float8_e4m3fn) and weight.data.device.type == "cuda"
+        with torch.cuda.stream(torch.cuda.current_stream(weight.data.device)):
+            return self.quantizer.dequantize(weight.data, self.scales)
 
-class DeepSpeedFPParameter(nn.Parameter):
-    """
-    DeepSpeedFP quantized parameter class that implements fp8/fp6
-    quantization deepspeed. Weights are stored in quantized form on
-    GPUs, and can be dequantized on-the-fly when needed by the model.
-    """
+    def quantize(self, weight, return_meta_tensor=True):
+        with torch.cuda.stream(torch.cuda.current_stream(weight.data.device)):
+            return self.quantizer.quantize(weight.data, return_meta_tensor=return_meta_tensor)
 
-    def __new__(cls, orig_shape: torch.Size, params_dtype: torch.dtype,
-                quant_config: DeepSpeedFPConfig):
+
+class DeepSpeedFPQuantizedParameter(nn.Parameter):
+    """
+    DeepSpeedFP quantized parameter class that implements weight quantization via deepspeed. Weights
+    are stored in quantized form on GPUs, and can be dequantized on-the-fly when
+    needed by the model. The weights are actually quantized during any `.to(device)`
+    if `device` is a cuda device.
+    """
+    def __new__(
+        cls,
+        data,
+        requires_grad: bool = False,  # quantized weights should be frozen by default
+        quantization: DeepSpeedFPConfig = None,
+        quantizer=None,  # HF expects this argument.
+    ):
+        if quantization is None:
+            quantization = DeepSpeedFPConfig()
+        self = torch.Tensor._make_subclass(cls, data, requires_grad)
+        self.quant_config = quantization
+        self.data = data
         from deepspeed.ops.fp_quantizer import FP_Quantize
-        data = torch.empty((
-            orig_shape.numel() // quant_config.group_size,
-            quant_config.group_size * quant_config.weight_bits // 8 + 4,
-        ), dtype=torch.int8)
-        self = torch.Tensor._make_subclass(cls, data, data.requires_grad)
-        self.orig_shape = orig_shape
-        self.quant_config = quant_config
-        self.fp_quantizer = FP_Quantize(group_size=quant_config.group_size)
-        self.fp_quantizer.orig_shape = orig_shape
-        self.fp_quantizer.orig_dtype = params_dtype
+        if quantizer is not None:
+            self.quantizer = quantizer
+        else:
+            self.quantizer = FP_Quantize(
+                group_size=quantization.group_size,
+            )
+        self._ensure_quantized(self)
         return self
 
-    def ds_quantize_(self, tensor: torch.Tensor):
-        assert tensor.device.type == "cuda" and tensor.dtype != torch.int8
-        return self.data.copy_(
-            self.fp_quantizer.quantize(
-                tensor.data,
-                q_bits=self.quant_config.weight_bits,
-            )
-        )
+    def _ensure_quantized(self, tensor: torch.Tensor, return_meta_tensor=True):
+        # If the tensor is on a cuda device and is not quantized, then quantize it in-place.
+        if tensor.device.type == "cuda" and tensor.dtype != torch.int8:
+            with torch.cuda.stream(torch.cuda.current_stream(tensor.device)):
+                bit16_data = tensor.data
+                tensor.data, self.scales = self.quantizer.quantize(bit16_data, q_bits=self.quant_config.weight_bits, return_meta_tensor=return_meta_tensor)
+                del bit16_data
+                bit16_data = None
+            assert tensor.dtype == torch.int8 or tensor.dtype == torch.float8_e4m3fn
 
-    def ds_dequantize(self, fp_out=None) -> torch.Tensor:
+    def quantization_scales(self):
+        return self.quantizer.get_scales()
+
+    def dequantized(self, fp_out=None) -> torch.Tensor:
         """
         Return a tensor containing the dequantized weights of this parameter.
         """
-        assert self.data.device.type == "cuda" and self.data.dtype == torch.int8
-        return self.fp_quantizer.dequantize(
-            self.data, fp_out=fp_out,
-            q_bits=self.quant_config.weight_bits)
+        if self.data.device.type == "cuda" and (self.data.dtype == torch.int8 or self.data.dtype == torch.float8_e4m3fn):
+            with torch.cuda.stream(torch.cuda.current_stream(self.data.device)):
+                return self.quantizer.dequantize(self.data, fp_out=fp_out, q_bits=self.quant_config.weight_bits)
+        return self.data
 
-    def ds_selective_dequantize(self, indices, fp_out=None) -> torch.Tensor:
+    def selective_dequantized(self, indices, fp_out=None) -> torch.Tensor:
+        """Return a tensor where only the weights at `indices` are dequantized (to save bandwidth)."""
+        if self.data.device.type == "cuda" and (self.data.dtype == torch.int8 or self.data.dtype == torch.float8_e4m3fn):
+            with torch.cuda.stream(torch.cuda.current_stream(self.data.device)):
+                return self.quantizer.selective_dequantize(self.data, 
+                                                           indices, 
+                                                           fp_out=fp_out, 
+                                                           q_bits=self.quant_config.weight_bits)
+        return self.data
+
+    def __getstate__(self):
+        state = self.__dict__
+        state["data"] = self.data
+        state["requires_grad"] = self.requires_grad
+        return state
+
+    def __setstate__(self, state):
+        self.quantizer = state["quantizer"]
+        self.data = state["data"]
+        self.requires_grad = state["requires_grad"]
+
+    def __deepcopy__(self, memo):
+        new_instance = type(self).__new__(type(self))
+        state = self.__getstate__()
+        new_instance.__setstate__(state)
+        new_instance.quantizer = copy.deepcopy(state["quantizer"])
+        new_instance.data = copy.deepcopy(state["data"])
+        return new_instance
+
+    def __copy__(self):
+        new_instance = type(self).__new__(type(self))
+        state = self.__getstate__()
+        new_instance.__setstate__(state)
+        return new_instance
+
+    def cuda(self, device=None, non_blocking=False):
+        return self.to(device="cuda" if device is None else device, non_blocking=non_blocking)
+
+    def to(self, *args, **kwargs):
         """
-        Return a tensor where only the weights at `indices` are dequantized
-        (to save HBM -> SRAM bandwidth).
+        Move the parameter to the given device. Then, if the device is a cuda device,
+        quantize it.
         """
-        assert self.data.device.type == "cuda" and self.data.dtype == torch.int8
-        return self.fp_quantizer.selective_dequantize(
-            self.data, indices, fp_out=fp_out,
-            q_bits=self.quant_config.weight_bits)
+        tensor = super().to(*args, **kwargs)
+        self._ensure_quantized(tensor)
+        return tensor
+
+    @property
+    def is_arctic(self):
+        return True
+
+    def cuda_parameter(self, device=None, non_blocking=False):
+        a = self.to(device="cuda" if device is None else device, non_blocking=non_blocking)
+        return torch.Tensor._make_subclass(DeepSpeedFPQuantizedParameter, a, self.requires_grad)

--- a/vllm/model_executor/models/arctic.py
+++ b/vllm/model_executor/models/arctic.py
@@ -1,45 +1,51 @@
-"""Inference-only Snowflake Arctic model."""
-import os
+"""Inference-only Arctic model."""
 from typing import Iterable, List, Optional, Tuple
+import os
+import time
 
 import torch
 from torch import nn
-from transformers import ArcticConfig
 
+from transformers import ArcticConfig
 from vllm.attention import Attention, AttentionMetadata
+from vllm.model_executor.layers.activation import SiluAndMul
+# from vllm.model_executor.layers.attention import Attention
 from vllm.distributed import (get_tensor_model_parallel_rank,
                               get_tensor_model_parallel_world_size,
                               tensor_model_parallel_all_reduce)
-from vllm.logger import init_logger
-from vllm.model_executor.layers.activation import SiluAndMul
-from vllm.model_executor.layers.fused_moe import fused_experts, fused_topk
 from vllm.model_executor.layers.layernorm import RMSNorm
+from vllm.model_executor.layers.fused_moe import fused_topk, fused_experts
 from vllm.model_executor.layers.linear import (LinearMethodBase,
                                                MergedColumnParallelLinear,
                                                QKVParallelLinear,
                                                ReplicatedLinear,
                                                RowParallelLinear)
-from vllm.model_executor.layers.logits_processor import LogitsProcessor
-from vllm.model_executor.layers.quantization.deepspeedfp import (
-    DeepSpeedFPLinearMethod, DeepSpeedFPParameter)
 from vllm.model_executor.layers.rotary_embedding import get_rope
-from vllm.model_executor.layers.sampler import Sampler
-from vllm.model_executor.layers.vocab_parallel_embedding import (
-    ParallelLMHead, VocabParallelEmbedding)
-from vllm.model_executor.model_loader.weight_utils import default_weight_loader
 from vllm.model_executor.sampling_metadata import SamplingMetadata
-from vllm.model_executor.utils import set_weight_attrs
+from vllm.model_executor.layers.vocab_parallel_embedding import (
+    VocabParallelEmbedding, ParallelLMHead)
 from vllm.sequence import SamplerOutput
+from vllm.model_executor.model_loader.weight_utils import default_weight_loader
+from vllm.model_executor.utils import set_weight_attrs
+from vllm.model_executor.layers.sampler import Sampler
+from vllm.model_executor.layers.quantization.deepspeedfp import DeepSpeedFPQuantizedParameter, DeepSpeedFPLinearMethod
+from vllm.model_executor.layers.logits_processor import LogitsProcessor
+from vllm.logger import init_logger
+
+from deepspeed.runtime.utils import see_memory_usage
+import gc
 
 logger = init_logger(__name__)
 use_dummy = os.environ.get("USE_DUMMY", False)
 use_dummy = bool(use_dummy)
 
+import time
+def sleep_infinity():
+    while True:
+        time.sleep(1)
 
 class ArcticMLP(nn.Module):
-
-    def __init__(self,
-                 config: ArcticConfig,
+    def __init__(self, config: ArcticConfig,
                  layer_id: int,
                  expert_id: int = -1,
                  is_residual_mlp: bool = False,
@@ -50,22 +56,22 @@ class ArcticMLP(nn.Module):
         self.expert_id = expert_id
         self.layer_id = layer_id
 
-        self.ffn_dim = config.intermediate_size if not is_residual_mlp \
-            else self.hidden_size
+        self.ffn_dim = config.intermediate_size if not is_residual_mlp else self.hidden_size
 
-        self.w13 = MergedColumnParallelLinear(self.hidden_size,
-                                              [self.ffn_dim] * 2,
-                                              bias=False,
-                                              linear_method=linear_method)
+        self.w13 = MergedColumnParallelLinear(
+            self.hidden_size, [self.ffn_dim] * 2,
+            bias=False,
+            linear_method=linear_method)
         self.w2 = RowParallelLinear(self.ffn_dim,
-                                    self.hidden_size,
-                                    bias=False,
-                                    reduce_results=reduce_results,
-                                    linear_method=linear_method)
+                                     self.hidden_size,
+                                     bias=False,
+                                     reduce_results=reduce_results,
+                                     linear_method=linear_method)
         if config.hidden_act != "silu":
             raise ValueError(f"Unsupported activation: {config.hidden_act}. "
                              "Only silu is supported for now.")
         self.act_fn = SiluAndMul()
+
 
     def forward(self, hidden_states):
         gate_up, _ = self.w13(hidden_states)
@@ -75,12 +81,12 @@ class ArcticMLP(nn.Module):
 
 
 class ArcticMoE(nn.Module):
-    """
-    Model-parallel implementation of Arctic MoE Layer.
+    """Model-parallel implementation of Arctic MoE Layer.
+
+    Note that Arctic has *every other* layer to be an MoE (different from Mixtral).
     """
 
-    def __init__(self,
-                 config: ArcticConfig,
+    def __init__(self, config: ArcticConfig,
                  layer_id: int,
                  tp_size: Optional[int] = None,
                  params_dtype: Optional[torch.dtype] = None,
@@ -95,18 +101,18 @@ class ArcticMoE(nn.Module):
         self.top_k = config.num_experts_per_tok
         self.intermediate_size = config.intermediate_size // self.tp_size
 
-        self.is_moe_layer = (layer_id + 1) % config.moe_layer_frequency == 0
-        self.is_quant = isinstance(linear_method, DeepSpeedFPLinearMethod)
+        self.is_moe_layer = (layer_id+1) % config.moe_layer_frequency == 0
+        self.is_quant = True #isinstance(linear_method, DeepSpeedFPLinearMethod)
         self.reduce_results = reduce_results
         # Some other parameters
         if params_dtype is None:
             params_dtype = torch.get_default_dtype()
         self.params_dtype = params_dtype
 
+        self.enable_dequantization_fusion = config.enable_dequantization_fusion
+
         if not self.is_moe_layer:
-            self.mlp = ArcticMLP(config,
-                                 layer_id=layer_id,
-                                 linear_method=linear_method,
+            self.mlp = ArcticMLP(config, layer_id=layer_id, linear_method=linear_method,
                                  reduce_results=reduce_results)
         else:
             self.gate = ReplicatedLinear(self.hidden_size,
@@ -114,23 +120,25 @@ class ArcticMoE(nn.Module):
                                          bias=False,
                                          params_dtype=self.params_dtype,
                                          linear_method=linear_method)
+
+            # Create it on CPU and later quantize it to GPU.
             if self.is_quant:
-                self.ws = DeepSpeedFPParameter(
-                    torch.Size((self.num_experts,
+                self.ws = DeepSpeedFPQuantizedParameter(
+                    torch.empty(self.num_experts,
                                 2 * self.intermediate_size,
-                                self.hidden_size)),
-                    params_dtype=params_dtype,
-                    quant_config=linear_method.quant_config,
-                )
-                torch.cuda.empty_cache()
-                self.w2s = DeepSpeedFPParameter(
-                    torch.Size((self.num_experts,
                                 self.hidden_size,
-                                self.intermediate_size)),
-                    params_dtype=params_dtype,
-                    quant_config=linear_method.quant_config,
+                                dtype=self.params_dtype).cpu(),
+                    requires_grad=False,
+                    quantization=linear_method.quant_config,
                 )
-                torch.cuda.empty_cache()
+                self.w2s = DeepSpeedFPQuantizedParameter(
+                    torch.empty(self.num_experts,
+                                self.hidden_size,
+                                self.intermediate_size,
+                                dtype=self.params_dtype).cpu(),
+                    requires_grad=False,
+                    quantization=linear_method.quant_config,
+                )
             else:
                 self.ws = nn.Parameter(
                     torch.empty(self.num_experts,
@@ -148,16 +156,13 @@ class ArcticMoE(nn.Module):
                 "weight_loader": self.weight_loader,
             })
             set_weight_attrs(self.w2s, {
-                "weight_loader": self.weight_loader,
+                "weight_loader": self.weight_loader,                
             })
 
     def weight_loader(self, param: nn.Parameter, loaded_weight: torch.Tensor,
                       weight_name: str, expert_id: int):
         tp_rank = get_tensor_model_parallel_rank()
-        if self.is_quant:
-            param_data = param.ds_dequantize()
-        else:
-            param_data = param.data
+        param_data = param.data
         shard_size = self.intermediate_size
         shard = slice(tp_rank * shard_size, (tp_rank + 1) * shard_size)
         if weight_name.endswith("w1.weight"):
@@ -167,48 +172,45 @@ class ArcticMoE(nn.Module):
                        shard_size:2 * shard_size, :] = loaded_weight[shard, :]
         if weight_name.endswith("w2.weight"):
             param_data[expert_id, :, :] = loaded_weight[:, shard]
-        if self.is_quant:
-            param.ds_quantize_(param_data)
 
     def local_moe_fused(self, hidden_states: torch.Tensor) -> torch.Tensor:
         num_tokens, hidden_size = hidden_states.shape
         hidden_states = hidden_states.view(-1, self.hidden_size)
         # router_logits: (num_tokens, n_experts)
         router_logits, _ = self.gate(hidden_states)
-        do_normalize = self.top_k > 1
+        do_normalize = True if self.top_k > 1 else False
         topk_weights, topk_ids = fused_topk(hidden_states,
                                             router_logits,
                                             self.top_k,
-                                            renormalize=do_normalize)
+                                            renormalize=do_normalize)        
         # topk_ids: (num_tokens, k)
-        if self.is_quant:
+        if self.is_quant and (not self.enable_dequantization_fusion):
             if 2 * num_tokens <= self.num_experts:
                 # If much fewer tokens than experts, use selective dequantize.
-                ws_dequantized = self.ws.ds_selective_dequantize(
-                    topk_ids.flatten())
-                w2s_dequantized = self.w2s.ds_selective_dequantize(
-                    topk_ids.flatten())
+                ws_dequantized = self.ws.selective_dequantized(topk_ids.flatten())
+                w2s_dequantized = self.w2s.selective_dequantized(topk_ids.flatten())
                 # We gathered the experts to the tokens so update the mapping.
                 topk_ids = torch.arange(
-                    0,
-                    topk_ids.numel(),
+                    0, topk_ids.numel(),
                     device=topk_ids.device,
                 ).reshape(topk_ids.shape)
-            else:
-                ws_dequantized = self.ws.ds_dequantize()
-                w2s_dequantized = self.w2s.ds_dequantize()
+            else:                
+                ws_dequantized = self.ws.dequantized()
+                w2s_dequantized = self.w2s.dequantized()
 
-        final_hidden_states = fused_experts(
-            hidden_states,
-            ws_dequantized if self.is_quant else self.ws,
-            w2s_dequantized if self.is_quant else self.w2s,
-            topk_weights,
-            topk_ids,
-            inplace=True)
+        final_hidden_states = fused_experts(hidden_states,
+                                            ws_dequantized if (self.is_quant and not self.enable_dequantization_fusion) else self.ws.data,
+                                            w2s_dequantized if (self.is_quant and not self.enable_dequantization_fusion) else self.w2s.data,
+                                            topk_weights,
+                                            topk_ids,
+                                            inplace=True,
+                                            w1_q_scales=self.ws.quantization_scales() if self.enable_dequantization_fusion else None,
+                                            w2_q_scales=self.w2s.quantization_scales() if self.enable_dequantization_fusion else None,
+                                            quantization_group_size=self.ws.quant_config.group_size if self.is_quant else 1)
         if self.reduce_results and self.tp_size > 1:
-            final_hidden_states = tensor_model_parallel_all_reduce(
-                final_hidden_states)
+            final_hidden_states = tensor_model_parallel_all_reduce(final_hidden_states)
         return final_hidden_states.view(num_tokens, hidden_size)
+
 
     def forward(self, hidden_states: torch.Tensor):
         if self.is_moe_layer:
@@ -219,9 +221,8 @@ class ArcticMoE(nn.Module):
 
 
 class ArcticAttention(nn.Module):
-
-    def __init__(self,
-                 config: ArcticConfig,
+    def __init__(self, 
+                 config: ArcticConfig, 
                  layer_idx: Optional[int] = None,
                  linear_method: Optional[LinearMethodBase] = None):
         super().__init__()
@@ -243,16 +244,19 @@ class ArcticAttention(nn.Module):
         self.q_size = self.num_heads * self.head_dim
         self.kv_size = self.num_kv_heads * self.head_dim
 
+
         self.max_position_embeddings = config.max_position_embeddings
-        self.rope_theta = config.rope_theta
+        self.rope_theta = config.rope_theta        
         self.scaling = self.head_dim**-0.5
 
-        self.qkv_proj = QKVParallelLinear(self.hidden_size,
-                                          self.head_dim,
-                                          self.total_num_heads,
-                                          self.total_num_kv_heads,
-                                          bias=False,
-                                          linear_method=linear_method)
+        self.qkv_proj = QKVParallelLinear(
+            self.hidden_size,
+            self.head_dim,
+            self.total_num_heads,
+            self.total_num_kv_heads,
+            bias=False,
+            linear_method=linear_method
+        )
         self.o_proj = RowParallelLinear(
             self.total_num_heads * self.head_dim,
             self.hidden_size,
@@ -269,10 +273,12 @@ class ArcticAttention(nn.Module):
             is_neox_style=True,
         )
 
-        self.attn = Attention(self.num_heads,
-                              self.head_dim,
-                              self.scaling,
-                              num_kv_heads=self.num_kv_heads)
+        self.attn = Attention(
+            self.num_heads,
+            self.head_dim,
+            self.scaling,
+            num_kv_heads=self.num_kv_heads
+        )
 
     def forward(
         self,
@@ -288,9 +294,7 @@ class ArcticAttention(nn.Module):
         output, _ = self.o_proj(attn_output)
         return output
 
-
 class ArcticDecoderLayer(nn.Module):
-
     def __init__(
         self,
         config: ArcticConfig,
@@ -300,29 +304,21 @@ class ArcticDecoderLayer(nn.Module):
         super().__init__()
         self.layer_idx = layer_idx
         self.hidden_size = config.hidden_size
-        is_moe_layer = (layer_idx + 1) % config.moe_layer_frequency == 0
+        is_moe_layer = (layer_idx+1) % config.moe_layer_frequency == 0
         self.use_residual = config.use_residual and is_moe_layer
-        self.self_attn = ArcticAttention(config,
-                                         layer_idx,
-                                         linear_method=linear_method)
-        self.block_sparse_moe = ArcticMoE(
-            config,
-            layer_id=layer_idx,
-            linear_method=linear_method,
-            reduce_results=(not self.use_residual))
+        self.self_attn = ArcticAttention(config, layer_idx, linear_method=linear_method)
+        self.block_sparse_moe = ArcticMoE(config,
+                                          layer_id=layer_idx, 
+                                          linear_method=linear_method,
+                                          reduce_results=(not self.use_residual))
 
-        self.input_layernorm = RMSNorm(config.hidden_size,
-                                       eps=config.rms_norm_eps)
-        self.post_attention_layernorm = RMSNorm(config.hidden_size,
-                                                eps=config.rms_norm_eps)
+        self.input_layernorm = RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+        self.post_attention_layernorm = RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
 
         if self.use_residual:
-            self.residual_layernorm = RMSNorm(config.hidden_size,
-                                              eps=config.rms_norm_eps)
-            self.residual_mlp = ArcticMLP(config,
-                                          layer_id=layer_idx,
-                                          is_residual_mlp=True,
-                                          reduce_results=False)
+            self.residual_layernorm = RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+            self.residual_mlp = ArcticMLP(config, layer_id=layer_idx, is_residual_mlp=True,
+                                       reduce_results=False)
 
     def forward(
         self,
@@ -359,7 +355,6 @@ class ArcticDecoderLayer(nn.Module):
 
 
 class ArcticModel(nn.Module):
-
     def __init__(
         self,
         config: ArcticConfig,
@@ -367,13 +362,16 @@ class ArcticModel(nn.Module):
     ) -> None:
         super().__init__()
         self.padding_idx = config.pad_token_id
-        self.vocab_size = config.vocab_size
+        self.vocab_size = config.vocab_size        
         self.embed_tokens = VocabParallelEmbedding(
             self.vocab_size,
             config.hidden_size,
-            org_num_embeddings=self.vocab_size)
+            org_num_embeddings=self.vocab_size
+        )
         self.layers = nn.ModuleList([
-            ArcticDecoderLayer(config, layer_idx, linear_method=linear_method)
+            ArcticDecoderLayer(config, 
+                            layer_idx,
+                            linear_method=linear_method)
             for layer_idx in range(config.num_hidden_layers)
         ])
         self._attn_implementation = config._attn_implementation
@@ -389,19 +387,26 @@ class ArcticModel(nn.Module):
         hidden_states = self.embed_tokens(input_ids)
         for i in range(len(self.layers)):
             layer = self.layers[i]
-            hidden_states = layer(positions, hidden_states, kv_caches[i],
-                                  attn_metadata)
+            hidden_states = layer(positions, hidden_states,
+                                  kv_caches[i], attn_metadata)
         hidden_states = self.norm(hidden_states)
         return hidden_states
 
 
 class ArcticForCausalLM(nn.Module):
-
-    def __init__(self,
-                 config: ArcticConfig,
-                 linear_method: Optional[LinearMethodBase] = None,
-                 **kwargs) -> None:
+    def __init__(
+        self, 
+        config: ArcticConfig,
+        linear_method: Optional[LinearMethodBase] = None,
+        **kwargs
+    ) -> None:
         super().__init__()
+        
+        enable_dequantization_fusion = True
+        if 'enable_dequantization_fusion' in kwargs:
+            enable_dequantization_fusion = kwargs['enable_dequantization_fusion']
+        config.enable_dequantization_fusion = enable_dequantization_fusion
+
         self.model = ArcticModel(config, linear_method)
         self.config = config
         self.linear_method = linear_method
@@ -416,16 +421,14 @@ class ArcticForCausalLM(nn.Module):
         self.logits_processor = LogitsProcessor(self.unpadded_vocab_size,
                                                 config.vocab_size)
         self.sampler = Sampler()
-
-    def forward(
-        self,
-        input_ids: torch.Tensor,
-        positions: torch.Tensor,
-        kv_caches: List[torch.Tensor],
-        attn_metadata: AttentionMetadata,
-    ) -> torch.Tensor:
-        hidden_states = self.model(input_ids, positions, kv_caches,
-                                   attn_metadata)
+        
+    def forward(self,
+                input_ids: torch.Tensor,
+                positions: torch.Tensor,
+                kv_caches: List[torch.Tensor],
+                attn_metadata: AttentionMetadata,
+            ) -> torch.Tensor:
+        hidden_states = self.model(input_ids, positions, kv_caches, attn_metadata)
         return hidden_states
 
     def compute_logits(self, hidden_states: torch.Tensor,
@@ -454,76 +457,88 @@ class ArcticForCausalLM(nn.Module):
         expert_params_mapping = []
         num_layers = self.config.num_hidden_layers
 
-        for layer in range(num_layers):
-            mlp_params_mapping.append((
-                f"layers.{layer}.residual_mlp.w13.weight",
-                f"layers.{layer}.residual_mlp.w1.weight", 0))
-            mlp_params_mapping.append((
-                f"layers.{layer}.residual_mlp.w13.weight",
-                f"layers.{layer}.residual_mlp.w3.weight", 1))
-            if layer % 2 == 0:
+        for i in range(num_layers):
+            for weight_name in ["w1", "w3"]:
+                mapping = (f"layers.{i}.residual_mlp.w13.weight", 
+                            f"layers.{i}.residual_mlp.{weight_name}.weight",
+                            0 if weight_name == "w1" else 1)
+                mlp_params_mapping.append(mapping)
+            if i % 2 == 0:
                 # MLP layers
-                mlp_params_mapping.append((
-                    f"layers.{layer}.block_sparse_moe.mlp.w13.weight",
-                    f"layers.{layer}.block_sparse_moe.mlp.w1.weight", 0))
-                mlp_params_mapping.append((
-                    f"layers.{layer}.block_sparse_moe.mlp.w13.weight",
-                    f"layers.{layer}.block_sparse_moe.mlp.w3.weight", 1))
+                for weight_name in ["w1", "w3"]:
+                    mapping = (f"layers.{i}.block_sparse_moe.mlp.w13.weight", 
+                                f"layers.{i}.block_sparse_moe.mlp.{weight_name}.weight",
+                                0 if weight_name == "w1" else 1)
+                    mlp_params_mapping.append(mapping)
             else:
                 # MoE layers
                 for expert_id in range(self.config.num_local_experts):
-                    expert_params_mapping.append((
-                        "ws", f"experts.{expert_id}.w1.weight", expert_id))
-                    expert_params_mapping.append((
-                        "w2s", f"experts.{expert_id}.w2.weight", expert_id))
-                    expert_params_mapping.append((
-                        "ws", f"experts.{expert_id}.w3.weight", expert_id))
+                    for weight_name in ["w1", "w2", "w3"]:
+                        if weight_name in ["w1", "w3"]:
+                            mapping = ("ws", f"experts.{expert_id}.{weight_name}.weight", expert_id)
+                        else:
+                            mapping = ("w2s", f"experts.{expert_id}.{weight_name}.weight", expert_id)
+                        expert_params_mapping.append(mapping)
 
         params_dict = dict(self.named_parameters())
 
-        logger.info(
-            "It takes ~10 minutes to load the weights. Please be patient.")
-        for name, loaded_weight in weights:
-            for (param_name, weight_name,
-                    shard_id) in stacked_params_mapping:
-                if weight_name not in name:
-                    continue
-                name = name.replace(weight_name, param_name)
-                # Skip loading extra bias for GPTQ models.
-                if name.endswith(".bias") and name not in params_dict:
-                    continue
-                param = params_dict[name]
-                weight_loader = param.weight_loader
-                weight_loader(param, loaded_weight, shard_id)
-                break
-            else:
-                for param_name, weight_name, shard_id in mlp_params_mapping:
+        if use_dummy:
+            logger.info("Using dummy weights. Skip loading weights.")
+        else:
+            logger.info("It takes ~10 mins to load the weights. Please be patient.")
+            for name, loaded_weight in weights:
+                original_name = name
+                for (param_name, weight_name, shard_id) in stacked_params_mapping:
                     if weight_name not in name:
                         continue
                     name = name.replace(weight_name, param_name)
+                    # Skip loading extra bias for GPTQ models.
+                    if name.endswith(".bias") and name not in params_dict:
+                        continue
                     param = params_dict[name]
                     weight_loader = param.weight_loader
+                    tik = time.time()
                     weight_loader(param, loaded_weight, shard_id)
                     break
                 else:
-                    for param_name, weight_name, shard_id \
-                            in expert_params_mapping:
+                    for param_name, weight_name, shard_id in mlp_params_mapping:
                         if weight_name not in name:
                             continue
                         name = name.replace(weight_name, param_name)
                         param = params_dict[name]
                         weight_loader = param.weight_loader
-                        weight_loader(param,
-                                        loaded_weight,
-                                        weight_name,
-                                        expert_id=shard_id)
+                        tik = time.time()
+                        weight_loader(param, loaded_weight, shard_id)
                         break
-                    else:
-                        if name.endswith(
-                                ".bias") and name not in params_dict:
-                            continue
-                        param = params_dict[name]
+                    else:        
+                        for param_name, weight_name, shard_id in expert_params_mapping:
+                            if weight_name not in name:
+                                continue
+                            name = name.replace(weight_name, param_name)
+                            param = params_dict[name]
+                            weight_loader = param.weight_loader
+                            tik = time.time()
+                            weight_loader(param, loaded_weight, weight_name, expert_id=shard_id)
+                            break
+                        else:
+                            if name.endswith(".bias") and name not in params_dict:
+                                continue
+                            param = params_dict[name]
 
-                        weight_loader = getattr(param, "weight_loader",
-                                                default_weight_loader)
-                        weight_loader(param, loaded_weight)
+                            weight_loader = getattr(param, "weight_loader",
+                                                    default_weight_loader)
+                            weight_loader(param, loaded_weight)
+
+        # For Arctic, we run a post quantization, because the weights are saved in 16 bits.
+        # Iterate in order of largest to smallest params to reduce fragmentation issues.
+        see_memory_usage(f"================= Before checkpoint laoding/quantization finished", force=True)
+
+        for name, param in sorted(self.named_parameters(), key=lambda v: -v[1].numel()):
+            if hasattr(param, "is_arctic") and param.is_arctic == True:
+                # do quantization after loading and moe to GPU
+                assert param.device.type != "cuda"
+                param.data = param.cuda()
+        
+        gc.collect()
+        torch.cuda.empty_cache()
+        see_memory_usage(f"****************** After checkpoint laoding/quantization finished", force=True)


### PR DESCRIPTION
This PR adds the fp8 version of the fused-moe for fusing the dequantization with the moe-gemm.
The initial performance evaluation shows between 15% to 33% speedup running inference with #token between 1 to 8K.
To run benchmark with this branch, please use [this branch](https://github.com/Snowflake-Labs/DeepSpeed/commit/a83b384f825e51c667a08bec1b9f3dfa4a99c839) of deepspeed.

- [ ] TODO: check the performance for different batch sizes on the right environment.
- [ ] TODO: check the accuracy before releasing this feature.